### PR TITLE
Allow leading blank line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"dev": true
+		},
 		"@types/mocha": {
 			"version": "2.2.48",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -16,34 +22,13 @@
 			"integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==",
 			"dev": true
 		},
-		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+		"agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"dev": true,
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
-			}
-		},
-		"ansi-cyan": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-			"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-			"dev": true,
-			"requires": {
-				"ansi-wrap": "0.1.0"
-			}
-		},
-		"ansi-red": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
-			"dev": true,
-			"requires": {
-				"ansi-wrap": "0.1.0"
+				"debug": "4"
 			}
 		},
 		"ansi-regex": {
@@ -58,21 +43,6 @@
 			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 			"dev": true
 		},
-		"ansi-wrap": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-			"dev": true
-		},
-		"append-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-			"integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-			"dev": true,
-			"requires": {
-				"buffer-equal": "^1.0.0"
-			}
-		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -81,94 +51,6 @@
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
-		},
-		"arr-diff": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-			"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-			"dev": true,
-			"requires": {
-				"arr-flatten": "^1.0.1",
-				"array-slice": "^0.2.3"
-			}
-		},
-		"arr-flatten": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
-		},
-		"arr-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-			"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
-			"dev": true
-		},
-		"array-differ": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-			"dev": true
-		},
-		"array-slice": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-			"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
-			"dev": true
-		},
-		"array-union": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true,
-			"requires": {
-				"array-uniq": "^1.0.1"
-			}
-		},
-		"array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-			"dev": true
-		},
-		"arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
-		},
-		"asn1": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
-			"requires": {
-				"safer-buffer": "~2.1.0"
-			}
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
-		},
-		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -202,24 +84,6 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
-			"requires": {
-				"tweetnacl": "^0.14.3"
-			}
-		},
-		"block-stream": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"dev": true,
-			"requires": {
-				"inherits": "~2.0.0"
-			}
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -231,21 +95,9 @@
 			}
 		},
 		"browser-stdout": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-			"dev": true
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-			"dev": true
-		},
-		"buffer-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
 		"buffer-from": {
@@ -258,12 +110,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
-		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
 		"chalk": {
@@ -297,35 +143,6 @@
 				}
 			}
 		},
-		"clone": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-			"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-			"dev": true
-		},
-		"clone-buffer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-			"dev": true
-		},
-		"clone-stats": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-			"dev": true
-		},
-		"cloneable-readable": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
-			}
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -341,15 +158,6 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
-		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-			"dev": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"commander": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
@@ -362,62 +170,14 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"convert-source-map": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.1"
-			}
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
-		},
 		"debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 			"dev": true,
 			"requires": {
-				"ms": "2.0.0"
+				"ms": "2.1.2"
 			}
-		},
-		"deep-assign": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
-			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-			"dev": true,
-			"requires": {
-				"is-obj": "^1.0.0"
-			}
-		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
-			"requires": {
-				"object-keys": "^1.0.12"
-			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -425,41 +185,19 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
-		"duplexer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
 			"dev": true
 		},
-		"duplexify": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0",
-				"stream-shift": "^1.0.0"
-			}
-		},
-		"ecc-jsbn": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
-			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
-		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"dev": true,
-			"requires": {
-				"once": "^1.4.0"
+				"es6-promise": "^4.0.3"
 			}
 		},
 		"escape-string-regexp": {
@@ -480,138 +218,11 @@
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
 		},
-		"event-stream": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-			"dev": true,
-			"requires": {
-				"duplexer": "~0.1.1",
-				"from": "~0",
-				"map-stream": "~0.1.0",
-				"pause-stream": "0.0.11",
-				"split": "0.3",
-				"stream-combiner": "~0.0.4",
-				"through": "~2.3.1"
-			}
-		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
-		},
-		"extend-shallow": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-			"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-			"dev": true,
-			"requires": {
-				"kind-of": "^1.1.0"
-			}
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
-		},
-		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-			"dev": true
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
-		},
-		"fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-			"dev": true,
-			"requires": {
-				"pend": "~1.2.0"
-			}
-		},
-		"flush-write-stream": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.3.6"
-			}
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
-		},
-		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
-		},
-		"from": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-			"dev": true
-		},
-		"fs-mkdirp-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-			"integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"through2": "^2.0.3"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
-		},
-		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			}
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0"
-			}
 		},
 		"glob": {
 			"version": "7.1.3",
@@ -627,260 +238,11 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"glob-parent": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-			"dev": true,
-			"requires": {
-				"is-glob": "^3.1.0",
-				"path-dirname": "^1.0.0"
-			}
-		},
-		"glob-stream": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-			"integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-			"dev": true,
-			"requires": {
-				"extend": "^3.0.0",
-				"glob": "^7.1.1",
-				"glob-parent": "^3.1.0",
-				"is-negated-glob": "^1.0.0",
-				"ordered-read-streams": "^1.0.0",
-				"pumpify": "^1.3.5",
-				"readable-stream": "^2.1.5",
-				"remove-trailing-separator": "^1.0.1",
-				"to-absolute-glob": "^2.0.0",
-				"unique-stream": "^2.0.2"
-			}
-		},
-		"graceful-fs": {
-			"version": "4.1.15",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-			"dev": true
-		},
 		"growl": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"gulp-chmod": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
-			"integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
-			"dev": true,
-			"requires": {
-				"deep-assign": "^1.0.0",
-				"stat-mode": "^0.2.0",
-				"through2": "^2.0.0"
-			}
-		},
-		"gulp-filter": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
-			"integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
-			"dev": true,
-			"requires": {
-				"multimatch": "^2.0.0",
-				"plugin-error": "^0.1.2",
-				"streamfilter": "^1.0.5"
-			}
-		},
-		"gulp-gunzip": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
-			"integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
-			"dev": true,
-			"requires": {
-				"through2": "~0.6.5",
-				"vinyl": "~0.4.6"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
-					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
-					}
-				}
-			}
-		},
-		"gulp-remote-src-vscode": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
-			"integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
-			"dev": true,
-			"requires": {
-				"event-stream": "3.3.4",
-				"node.extend": "^1.1.2",
-				"request": "^2.79.0",
-				"through2": "^2.0.3",
-				"vinyl": "^2.0.1"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
-			}
-		},
-		"gulp-untar": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
-			"integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
-			"dev": true,
-			"requires": {
-				"event-stream": "~3.3.4",
-				"streamifier": "~0.1.1",
-				"tar": "^2.2.1",
-				"through2": "~2.0.3",
-				"vinyl": "^1.2.0"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
-				},
-				"replace-ext": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"dev": true,
-					"requires": {
-						"clone": "^1.0.0",
-						"clone-stats": "^0.0.1",
-						"replace-ext": "0.0.1"
-					}
-				}
-			}
-		},
-		"gulp-vinyl-zip": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
-			"integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
-			"dev": true,
-			"requires": {
-				"event-stream": "3.3.4",
-				"queue": "^4.2.1",
-				"through2": "^2.0.3",
-				"vinyl": "^2.0.2",
-				"vinyl-fs": "^3.0.3",
-				"yauzl": "^2.2.1",
-				"yazl": "^2.2.1"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
-			}
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
-		},
-		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"dev": true,
-			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
-			}
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
 		},
 		"has-ansi": {
 			"version": "2.0.0",
@@ -897,27 +259,31 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
-		"has-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-			"dev": true
-		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
 			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
 			"dev": true
 		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+		"http-proxy-agent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
+			}
+		},
+		"https-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"dev": true,
+			"requires": {
+				"agent-base": "6",
+				"debug": "4"
 			}
 		},
 		"inflight": {
@@ -936,109 +302,6 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
-		"is": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
-			"integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
-			"dev": true
-		},
-		"is-absolute": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-			"dev": true,
-			"requires": {
-				"is-relative": "^1.0.0",
-				"is-windows": "^1.0.1"
-			}
-		},
-		"is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
-		},
-		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
-		},
-		"is-glob": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-			"dev": true,
-			"requires": {
-				"is-extglob": "^2.1.0"
-			}
-		},
-		"is-negated-glob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-			"dev": true
-		},
-		"is-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
-		},
-		"is-relative": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-			"dev": true,
-			"requires": {
-				"is-unc-path": "^1.0.0"
-			}
-		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
-		},
-		"is-unc-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-			"dev": true,
-			"requires": {
-				"unc-path-regex": "^0.1.2"
-			}
-		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
-		},
-		"is-valid-glob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-			"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-			"dev": true
-		},
-		"is-windows": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
-		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1053,93 +316,6 @@
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
-			}
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
-		},
-		"json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
-		},
-		"json-stable-stringify-without-jsonify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-			"dev": true
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			}
-		},
-		"kind-of": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-			"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
-			"dev": true
-		},
-		"lazystream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.5"
-			}
-		},
-		"lead": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
-			"integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-			"dev": true,
-			"requires": {
-				"flush-write-stream": "^1.0.2"
-			}
-		},
-		"map-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-			"dev": true
-		},
-		"mime-db": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.22",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
-			"dev": true,
-			"requires": {
-				"mime-db": "~1.38.0"
 			}
 		},
 		"minimatch": {
@@ -1167,34 +343,38 @@
 			}
 		},
 		"mocha": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
 			"dev": true,
 			"requires": {
-				"browser-stdout": "1.3.0",
-				"commander": "2.11.0",
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
 				"debug": "3.1.0",
-				"diff": "3.3.1",
+				"diff": "3.5.0",
 				"escape-string-regexp": "1.0.5",
 				"glob": "7.1.2",
-				"growl": "1.10.3",
+				"growl": "1.10.5",
 				"he": "1.1.1",
+				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
-				"supports-color": "4.4.0"
+				"supports-color": "5.4.0"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
 					"dev": true
 				},
-				"diff": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-					"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-					"dev": true
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
 				},
 				"glob": {
 					"version": "7.1.2",
@@ -1210,92 +390,28 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
-				"has-flag": {
+				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				},
 				"supports-color": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
-		},
-		"multimatch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"dev": true,
-			"requires": {
-				"array-differ": "^1.0.0",
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"minimatch": "^3.0.0"
-			}
-		},
-		"node.extend": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
-			"integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3",
-				"is": "^3.2.1"
-			}
-		},
-		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
-		},
-		"now-and-later": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
-			"integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.2"
-			}
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
-		},
-		"object-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-			"integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
-			"dev": true
-		},
-		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
-			}
 		},
 		"once": {
 			"version": "1.4.0",
@@ -1305,21 +421,6 @@
 			"requires": {
 				"wrappy": "1"
 			}
-		},
-		"ordered-read-streams": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-			"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.1"
-			}
-		},
-		"path-dirname": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -1333,182 +434,6 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
-		"pause-stream": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"dev": true,
-			"requires": {
-				"through": "~2.3"
-			}
-		},
-		"pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-			"dev": true
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
-		},
-		"plugin-error": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-			"dev": true,
-			"requires": {
-				"ansi-cyan": "^0.1.1",
-				"ansi-red": "^0.1.1",
-				"arr-diff": "^1.0.1",
-				"arr-union": "^2.0.1",
-				"extend-shallow": "^1.1.2"
-			}
-		},
-		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
-		},
-		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-			"dev": true
-		},
-		"pump": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-			"dev": true,
-			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"pumpify": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-			"dev": true,
-			"requires": {
-				"duplexify": "^3.6.0",
-				"inherits": "^2.0.3",
-				"pump": "^2.0.0"
-			}
-		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
-		},
-		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-			"dev": true
-		},
-		"querystringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
-			"dev": true
-		},
-		"queue": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
-			"integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
-			"dev": true,
-			"requires": {
-				"inherits": "~2.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"remove-bom-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
-			"integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^1.1.5",
-				"is-utf8": "^0.2.1"
-			}
-		},
-		"remove-bom-stream": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
-			"integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-			"dev": true,
-			"requires": {
-				"remove-bom-buffer": "^3.0.0",
-				"safe-buffer": "^5.1.0",
-				"through2": "^2.0.3"
-			}
-		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
-		},
-		"replace-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-			"dev": true
-		},
-		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-			"dev": true,
-			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
-			}
-		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
-		},
 		"resolve": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -1517,36 +442,6 @@
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
-		},
-		"resolve-options": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
-			"integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-			"dev": true,
-			"requires": {
-				"value-or-function": "^3.0.0"
-			}
-		},
-		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.1.3"
-			}
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -1561,22 +456,13 @@
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.11",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-			"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			}
-		},
-		"split": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-			"dev": true,
-			"requires": {
-				"through": "2"
 			}
 		},
 		"sprintf-js": {
@@ -1584,68 +470,6 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
-		},
-		"sshpk": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dev": true,
-			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
-			}
-		},
-		"stat-mode": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-			"integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
-			"dev": true
-		},
-		"stream-combiner": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-			"dev": true,
-			"requires": {
-				"duplexer": "~0.1.1"
-			}
-		},
-		"stream-shift": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-			"dev": true
-		},
-		"streamfilter": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
-			"integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"streamifier": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
-			"integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
-			"dev": true
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -1661,80 +485,6 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 			"dev": true
-		},
-		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-			"dev": true,
-			"requires": {
-				"block-stream": "*",
-				"fstream": "^1.0.2",
-				"inherits": "2"
-			}
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
-		},
-		"through2": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~2.3.6",
-				"xtend": "~4.0.1"
-			}
-		},
-		"through2-filter": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
-			"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-			"dev": true,
-			"requires": {
-				"through2": "~2.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"to-absolute-glob": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-			"dev": true,
-			"requires": {
-				"is-absolute": "^1.0.0",
-				"is-negated-glob": "^1.0.0"
-			}
-		},
-		"to-through": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
-			"integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-			"dev": true,
-			"requires": {
-				"through2": "^2.0.3"
-			}
-		},
-		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-			"dev": true,
-			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
-			}
 		},
 		"tslib": {
 			"version": "1.9.3",
@@ -1772,227 +522,81 @@
 				"tslib": "^1.8.1"
 			}
 		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
-		},
 		"typescript": {
 			"version": "3.3.3333",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
 			"integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
 			"dev": true
 		},
-		"unc-path-regex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-			"dev": true
-		},
-		"unique-stream": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
-			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-			"dev": true,
-			"requires": {
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"through2-filter": "^3.0.0"
-			}
-		},
-		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
-		},
-		"url-parse": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
-			"integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
-			"dev": true,
-			"requires": {
-				"querystringify": "^2.0.0",
-				"requires-port": "^1.0.0"
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
-		},
-		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
-		},
-		"value-or-function": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-			"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
-			"dev": true
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
-			"requires": {
-				"assert-plus": "^1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
-			}
-		},
-		"vinyl": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-			"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-			"dev": true,
-			"requires": {
-				"clone": "^0.2.0",
-				"clone-stats": "^0.0.1"
-			}
-		},
-		"vinyl-fs": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-			"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-			"dev": true,
-			"requires": {
-				"fs-mkdirp-stream": "^1.0.0",
-				"glob-stream": "^6.1.0",
-				"graceful-fs": "^4.0.0",
-				"is-valid-glob": "^1.0.0",
-				"lazystream": "^1.0.0",
-				"lead": "^1.0.0",
-				"object.assign": "^4.0.4",
-				"pumpify": "^1.3.5",
-				"readable-stream": "^2.3.3",
-				"remove-bom-buffer": "^3.0.0",
-				"remove-bom-stream": "^1.2.0",
-				"resolve-options": "^1.1.0",
-				"through2": "^2.0.0",
-				"to-through": "^2.0.0",
-				"value-or-function": "^3.0.0",
-				"vinyl": "^2.0.0",
-				"vinyl-sourcemap": "^1.1.0"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
-			}
-		},
-		"vinyl-source-stream": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
-			"integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
-			"dev": true,
-			"requires": {
-				"through2": "^2.0.3",
-				"vinyl": "^0.4.3"
-			}
-		},
-		"vinyl-sourcemap": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
-			"integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-			"dev": true,
-			"requires": {
-				"append-buffer": "^1.0.2",
-				"convert-source-map": "^1.5.0",
-				"graceful-fs": "^4.1.6",
-				"normalize-path": "^2.1.1",
-				"now-and-later": "^2.0.0",
-				"remove-bom-buffer": "^3.0.0",
-				"vinyl": "^2.0.0"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-					"dev": true,
-					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
-					}
-				}
-			}
-		},
 		"vscode": {
-			"version": "1.1.30",
-			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.30.tgz",
-			"integrity": "sha512-YDj5w0TGOcS8XLIdekT4q6LlLV6hv1ZvuT2aGT3KJll4gMz6dUPDgo2VVAf0i0E8igbbZthwvmaUGRwW9yPIaw==",
+			"version": "1.1.37",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+			"integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.2",
-				"gulp-chmod": "^2.0.0",
-				"gulp-filter": "^5.0.1",
-				"gulp-gunzip": "1.0.0",
-				"gulp-remote-src-vscode": "^0.5.1",
-				"gulp-untar": "^0.0.7",
-				"gulp-vinyl-zip": "^2.1.2",
-				"mocha": "^4.0.1",
-				"request": "^2.88.0",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"mocha": "^5.2.0",
 				"semver": "^5.4.1",
 				"source-map-support": "^0.5.0",
-				"url-parse": "^1.4.3",
-				"vinyl-fs": "^3.0.3",
-				"vinyl-source-stream": "^1.1.0"
+				"vscode-test": "^0.4.1"
+			}
+		},
+		"vscode-test": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+			"integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+			"dev": true,
+			"requires": {
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"http-proxy-agent": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+					"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "4",
+						"debug": "3.1.0"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+					"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^4.3.0",
+						"debug": "^3.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
 			}
 		},
 		"wrappy": {
@@ -2000,31 +604,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
-		},
-		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
-		},
-		"yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-			"dev": true,
-			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
-		},
-		"yazl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-			"dev": true,
-			"requires": {
-				"buffer-crc32": "~0.2.3"
-			}
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,32 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.12.13"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"dev": true
+		},
+		"@babel/highlight": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.14.0",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -17,9 +43,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.14.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
-			"integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==",
+			"version": "10.17.59",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
+			"integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg==",
 			"dev": true
 		},
 		"agent-base": {
@@ -31,17 +57,14 @@
 				"debug": "4"
 			}
 		},
-		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
-		},
 		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -50,32 +73,6 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
-			}
-		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				}
 			}
 		},
 		"balanced-match": {
@@ -121,26 +118,6 @@
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"color-convert": {
@@ -159,9 +136,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
 		"concat-map": {
@@ -212,16 +189,16 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
 		},
-		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
 		"glob": {
@@ -244,13 +221,13 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-flag": {
@@ -302,16 +279,25 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
+		"is-core-module": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+			"integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-			"integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -435,11 +421,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
 			"dev": true,
 			"requires": {
+				"is-core-module": "^2.2.0",
 				"path-parse": "^1.0.6"
 			}
 		},
@@ -471,46 +458,48 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
-		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
-		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true
-		},
 		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"tslint": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
-			"integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.22.0",
+				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
 				"chalk": "^2.3.0",
 				"commander": "^2.12.1",
-				"diff": "^3.2.0",
+				"diff": "^4.0.1",
 				"glob": "^7.1.1",
-				"js-yaml": "^3.7.0",
+				"js-yaml": "^3.13.1",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"resolve": "^1.3.2",
 				"semver": "^5.3.0",
 				"tslib": "^1.8.0",
 				"tsutils": "^2.29.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
+				}
 			}
 		},
 		"tsutils": {
@@ -523,9 +512,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.3.3333",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-			"integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+			"version": "3.9.9",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+			"integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
 			"dev": true
 		},
 		"vscode": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
 	},
 	"devDependencies": {
 		"@types/mocha": "^2.2.42",
-		"@types/node": "^10.12.21",
-		"tslint": "^5.12.1",
-		"typescript": "^3.3.1",
+		"@types/node": "^10.17.59",
+		"tslint": "^5.20.1",
+		"typescript": "^3.9.9",
 		"vscode": "^1.1.37"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
 		"test": "npm run compile && node ./node_modules/vscode/bin/test"
 	},
 	"devDependencies": {
-		"typescript": "^3.3.1",
-		"vscode": "^1.1.28",
-		"tslint": "^5.12.1",
+		"@types/mocha": "^2.2.42",
 		"@types/node": "^10.12.21",
-		"@types/mocha": "^2.2.42"
+		"tslint": "^5.12.1",
+		"typescript": "^3.3.1",
+		"vscode": "^1.1.37"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,22 +34,23 @@ let handle_selection = (editor: vscode.TextEditor, builder: vscode.TextEditorEdi
 			// by itself
 			if (lines.length > 0 && lines[lines.length-1].match(/^\s*$/)) {
 				lines.pop();
-			}
+            }
 
-			let r = /^\s*/;
-			let match = new_content.match(r);
-			if (match && match.length > 0) {
-				// gotta remember to replace it
-				new_content = new_content.replace(r, '');
 
-				let prefix = match[0];
-				lines = lines.map(line => {
-					if (line.startsWith(prefix)) {
-						return line.slice(prefix.length);
-					}
-					return line;
-				});
-			}
+			// let r = /^\s*/;
+			// let match = new_content.match(r);
+			// if (match && match.length > 0) {
+			// 	// gotta remember to replace it
+			// 	new_content = new_content.replace(r, '');
+
+			// 	let prefix = match[0];
+			// 	lines = lines.map(line => {
+			// 		if (line.startsWith(prefix)) {
+			// 			return line.slice(prefix.length);
+			// 		}
+			// 		return line;
+			// 	});
+			// }
 
 			lines = lines.map(line => { return line_prefix + line; });
 			lines.unshift(new_content);
@@ -80,28 +81,7 @@ let paste_and_indent = () => {
 					});
 				}
 			});
-		});
-
-
-		// .then(success => {
-		// 	myedit.selections.forEach(selection => {
-		// 		let postion = selection.end;
-		// 		selection = new vscode.Selection(postion, postion);
-		// 	});
-		// });
-
-		// myedit.selections.forEach(selection => {
-		// 	myedit.edit((editBuilder: vscode.TextEditorEdit) => {
-		// 		editBuilder.replace(selection, "asdfasdfa");
-		// 	}).then(success => {
-		// 		if (success) {
-		// 			console.log('thig thing alkjsdflkjasdflkj');
-		// 			// make selection empty
-		// 			var postion = myedit.selection.end;
-		// 			selection = new vscode.Selection(postion, postion);
-		// 		}
-		// 	});
-		// });
+        });
 	}
 };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ let handle_selection = (editor: vscode.TextEditor, builder: vscode.TextEditorEdi
     let this_line = new vscode.Selection(start_line, selection.start);
 	// Note: this won't work if there are different indent styles
 	//       in the pasted code; tab characters.
-    let leading_whitespace_regex = (/^\s*$/)
+    let leading_whitespace_regex = (/^\s*/)
 	let line_contents = editor.document.getText(this_line);
     let line_match = line_contents.match(leading_whitespace_regex);
     let line_prefix = '';
@@ -15,12 +15,12 @@ let handle_selection = (editor: vscode.TextEditor, builder: vscode.TextEditorEdi
         line_prefix = line_match[0];
     }
     let lines = content.split('\n');
-    // Find the line with the least amount of initial whitespace and remove
-    // that much whitespace from each line; left justify paste.
+    // Find the pasted line with the least amount of initial whitespace and
+    // remove that much whitespace from each line; left justify paste.
     let dedent = null
     for (let line of lines) {
         if (line.trim().length > 0) {
-            let match = line.match(/^\s*/)
+            let match = line.match(leading_whitespace_regex)
             let leading_whitespace = ''
             if (match != null) {
                 leading_whitespace = match[0]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,65 +4,51 @@ import * as vscode from 'vscode';
 
 let handle_selection = (editor: vscode.TextEditor, builder: vscode.TextEditorEdit, selection: vscode.Selection, content: string) => {
 	let start_line = new vscode.Position(selection.start.line, 0);
-	let this_line = new vscode.Selection(start_line, selection.start);
-
-	// this only really works when you have a block selection that is all
-	// left aligned.
-
-	// to normalize the paste block, we need to:
-	// 1. look at the first line
-	// 2. count the whitespace
-	// 3. remove that exact content from every line
-
-	// need to handle the case where every line starts with the same number of
-	// whitespace characters. we should just be able to trim them.
-
-	// simple scenario where the content is all left aligned
-	// we just need to paste and repeat whatever the prefix
-	// is before all of this.
+    let this_line = new vscode.Selection(start_line, selection.start);
 	// Note: this won't work if there are different indent styles
-	//       in the pasted code
+	//       in the pasted code; tab characters.
     let leading_whitespace_regex = (/^\s*$/)
 	let line_contents = editor.document.getText(this_line);
     let line_match = line_contents.match(leading_whitespace_regex);
-	if (line_match && line_match.length > 0) {
-		let line_prefix = line_match[0];
-        let lines = content.split('\n');
-        // Find the line with the least amount of initial whitespace and remove
-        // that much whitespace from each line; left justify paste.
-        let dedent = null
-        for (let line of lines) {
-            if (line.trim().length > 0) {
-                let match = line.match(/^\s*/)
-                let leading_whitespace = ''
-                if (match != null) {
-                    leading_whitespace = match[0]
-                }
-                if (dedent == null || leading_whitespace.length < dedent.length) {
-                    dedent = leading_whitespace
-                }
+    let line_prefix = '';
+    if (line_match && line_match.length > 0) {
+        line_prefix = line_match[0];
+    }
+    let lines = content.split('\n');
+    // Find the line with the least amount of initial whitespace and remove
+    // that much whitespace from each line; left justify paste.
+    let dedent = null
+    for (let line of lines) {
+        if (line.trim().length > 0) {
+            let match = line.match(/^\s*/)
+            let leading_whitespace = ''
+            if (match != null) {
+                leading_whitespace = match[0]
+            }
+            if (dedent == null || leading_whitespace.length < dedent.length) {
+                dedent = leading_whitespace
             }
         }
-        if (dedent == null) {
-            dedent = ''
+    }
+    if (dedent == null) {
+        dedent = ''
+    }
+    let new_content = lines.shift();
+    if (new_content || new_content == '') {
+        // remove a last blank line
+        // there is almost always going to be a newline that ends up
+        // by itself
+        if (lines.length > 0 && lines[lines.length - 1].match(leading_whitespace_regex)) {
+            lines.pop();
         }
-		let new_content = lines.shift();
-        if (new_content || new_content == '') {
-			// remove a last blank line
-			// there is almost always going to be a newline that ends up
-			// by itself
-            if (lines.length > 0 && lines[lines.length - 1].match(leading_whitespace_regex)) {
-				lines.pop();
-            }
-            lines = lines.map(line => { return line_prefix + line.substring(dedent.length); });
-            lines.unshift(new_content.substring(dedent.length));
-			new_content = lines.join('\n');
+        lines = lines.map(line => { return line_prefix + line.substring(dedent.length); });
+        lines.unshift(new_content.substring(dedent.length));
+        new_content = lines.join('\n');
 
-			if (new_content) {
-				builder.replace(selection, new_content);
-			}
-		}
-	}
+        if (new_content) {
+            builder.replace(selection, new_content);
+        }
+    }
 };
 
 let paste_and_indent = () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ let handle_selection = (editor: vscode.TextEditor, builder: vscode.TextEditorEdi
 		let line_prefix = line_match[0];
 		let lines = content.split('\n');
 		let new_content = lines.shift();
-		if (new_content) {
+        if (new_content || new_content == '') {
 			// remove a last blank line
 			// there is almost always going to be a newline that ends up
 			// by itself
@@ -81,7 +81,7 @@ let paste_and_indent = () => {
 				}
 			});
 		});
-	
+
 
 		// .then(success => {
 		// 	myedit.selections.forEach(selection => {
@@ -97,7 +97,7 @@ let paste_and_indent = () => {
 		// 		if (success) {
 		// 			console.log('thig thing alkjsdflkjasdflkj');
 		// 			// make selection empty
-		// 			var postion = myedit.selection.end; 
+		// 			var postion = myedit.selection.end;
 		// 			selection = new vscode.Selection(postion, postion);
 		// 		}
 		// 	});


### PR DESCRIPTION
This allows paste buffers, that begin with newlines, to be handled.

I have tried all of the paste_and_indent VS Code extensions, all have some flaw.
```
    Paste and Indent by g3rry
        Some characters are always selected leading to loss of pasted content
    Indent on Paste by gazugafan
        No hotkey
        Reformats
    paste-and-indent by partkyle
        Pasted contents cannot begin with blank line
    Paste with Indent by anhnhoktvn
        Reformats
```
paste-and-indent is the superior extension, so I decided to solve the small problem I had with it. The content I wish to paste often begins with one or more blank lines. The result before this fix was that nothing would be pasted. After this fix, the blank lines are pasted and the following lines are indented as desired. 
Thank you for preparing this valuable extension.
